### PR TITLE
新規アドレス追加時のDuplicated keyエラーを解消

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -91,6 +91,9 @@ export default new Vuex.Store({
         commit('deleteAddress', { id });
       }
     },
+    clearAddresses({ commit }) {
+      commit('clearAddresses');
+    },
     showOverlay({ commit }) {
       commit('showOverlay');
     },

--- a/src/views/address/AddressForm.vue
+++ b/src/views/address/AddressForm.vue
@@ -45,11 +45,11 @@ export default {
         }
     },
     methods: {
-        submit() {
+        async submit() {
             if (this.$route.params.address_id) {
-                this.updateAddress({ id: this.$route.params.address_id, address: this.address});
+                await this.updateAddress({ id: this.$route.params.address_id, address: this.address});
             } else {
-                this.addAddress(this.address);
+                await this.addAddress(this.address);
             }
             this.$router.push({ name: 'address-list' });
             this.address = {}


### PR DESCRIPTION
新規アドレス追加時に、DBへの追加処理の完了を待たずに先の処理が実行されてしまいエラーが出ていた。
そのため、該当の処理をasync/awaitで書くことで、処理の順番に整合性を持たせエラーを解消した。